### PR TITLE
Use `vue-demi` for better backward compatibility

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -74,16 +74,21 @@
     "rollup-plugin-dts": "^4.2.2",
     "typescript": "^4.7.4",
     "vue": "^3.2.37",
+    "vue-demi": "^0.13.11",
     "vue2": "npm:vue@^2.7.0-0"
   },
   "peerDependencies": {
-    "vue": "^2.7.0-0 || >=3.2.0"
+    "vue": "^2.7.0-0 || >=3.2.0",
+    "vue-demi": "^0.0.0"
   },
   "peerDependenciesMeta": {
     "@vue/composition-api": {
       "optional": true
     },
     "vue": {
+      "optional": true
+    },
+    "vue-demi": {
       "optional": true
     }
   }

--- a/packages/runtime/rollup.config.types.js
+++ b/packages/runtime/rollup.config.types.js
@@ -12,7 +12,7 @@ const config = [
   {
     input: './types-vue3/main.d.ts',
     output: [{ file: 'dist-vue3/index.d.ts', format: 'es' }],
-    external: ['vue'],
+    external: ['vue-demi'],
     plugins: [
       dts({
         respectExternal: true,
@@ -31,7 +31,7 @@ const config = [
   {
     input: './types-vue2/main.d.ts',
     output: [{ file: 'dist-vue2/index.d.ts', format: 'es' }],
-    external: ['vue'],
+    external: ['vue-demi'],
     plugins: [
       dts({
         compilerOptions: {

--- a/packages/runtime/scripts/postinstall.js
+++ b/packages/runtime/scripts/postinstall.js
@@ -1,7 +1,7 @@
 /**
  * Inspired and partially copied from https://github.com/vueuse/vue-demi
  */
-const Vue = loadModule('vue')
+const Vue = loadModule('vue-demi')
 const { switchVersion } = require('./utils')
 
 if (!Vue || typeof Vue.version !== 'string') {

--- a/packages/runtime/scripts/utils.js
+++ b/packages/runtime/scripts/utils.js
@@ -15,28 +15,6 @@ function switchVersion(version) {
   pkg.exports['.'].require = pkg.main
   pkg.exports['.'].import = pkg.module
   fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2))
-
-  // copy('index.cjs.js', version, 'cjs')
-  // copy('index.es.js', version, 'es')
-  // TODO: copy types after having figured out how to build them for Vue 2.
-  // copy('index.d.ts', version)
 }
-
-// const distDir = path.resolve(__dirname, '..', 'dist')
-
-// function copy(targetName, version, moduleFormat) {
-//   // vue = vue || 'vue'
-//   const src = path.join(distDir, `index.vue${version}.${moduleFormat}.js`)
-//   const dest = path.join(distDir, targetName)
-//   let content = fs.readFileSync(src, 'utf-8')
-//   //content = content.replace(/'vue'/g, `'${vue}'`)
-//   // unlink for pnpm, #92
-//   try {
-//     fs.unlinkSync(dest)
-//   } catch {
-//     /* eslint-disable-next-line no-empty */
-//   }
-//   fs.writeFileSync(dest, content, 'utf-8')
-// }
 
 exports.switchVersion = switchVersion

--- a/packages/runtime/src/bridges/vue2/set-delete.ts
+++ b/packages/runtime/src/bridges/vue2/set-delete.ts
@@ -1,1 +1,1 @@
-export { set, del } from 'vue'
+export { set, del } from 'vue-demi'

--- a/packages/runtime/src/bridges/vue2/types.ts
+++ b/packages/runtime/src/bridges/vue2/types.ts
@@ -1,3 +1,3 @@
-import Vue from 'vue'
+import Vue from 'vue-demi'
 
 export type App = typeof Vue

--- a/packages/runtime/src/bridges/vue3/types.ts
+++ b/packages/runtime/src/bridges/vue3/types.ts
@@ -1,1 +1,1 @@
-export type { App } from 'vue'
+export type { App } from 'vue-demi'

--- a/packages/runtime/src/customDirectives.ts
+++ b/packages/runtime/src/customDirectives.ts
@@ -1,4 +1,4 @@
-import type { Directive, DirectiveBinding, DirectiveHook, VNode } from 'vue'
+import type { Directive, DirectiveBinding, DirectiveHook, VNode } from 'vue-demi'
 import { isVue2 } from './constants'
 
 const map = {

--- a/packages/runtime/src/defineComponent.ts
+++ b/packages/runtime/src/defineComponent.ts
@@ -1,6 +1,6 @@
 // We use 'vue-demi' as a virtual module here, it will be dynamically replaced with the right
 // import from the ./defineComponent/ folder during build.
-import { defineComponent as _defineComponent } from 'vue'
+import { defineComponent as _defineComponent } from 'vue-demi'
 import { isVue2 } from './constants'
 import { patchVModelProp } from './vModel'
 import { patchLifecycleHooks } from './lifecycleHooks'

--- a/packages/runtime/src/shims-vue2.d.ts
+++ b/packages/runtime/src/shims-vue2.d.ts
@@ -1,5 +1,5 @@
 declare module '*.vue' {
-  import Vue from 'vue'
+  import Vue from 'vue-demi'
   export default Vue
 }
 

--- a/packages/runtime/src/shims-vue3.d.ts
+++ b/packages/runtime/src/shims-vue3.d.ts
@@ -1,5 +1,5 @@
 declare module '*.vue' {
-  import { DefineComponent } from 'vue'
+  import { DefineComponent } from 'vue-demi'
   const component: DefineComponent<{}, {}, any>
   export default component
 }

--- a/packages/runtime/src/slotsMixin.ts
+++ b/packages/runtime/src/slotsMixin.ts
@@ -1,5 +1,5 @@
 import { isVue2 } from './constants'
-import { type VNode } from 'vue'
+import { type VNode } from 'vue-demi'
 type Slot = (...args: any[]) => VNode[]
 export const slotsMixin = {
   beforeCreate() {

--- a/packages/runtime/vite.config.ts
+++ b/packages/runtime/vite.config.ts
@@ -23,11 +23,11 @@ export default <UserConfig>{
     },
     emptyOutDir: !isVue2,
     rollupOptions: {
-      external: ['vue'],
+      external: ['vue-demi'],
       output: {
         banner: `
         /**
-         *  Copyright ${new Date(Date.now()).getFullYear()} Thorsten Luenborg 
+         *  Copyright ${new Date(Date.now()).getFullYear()} Thorsten Luenborg
          *  @license MIT
         **/
         `,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,7 @@ importers:
       tslib: ^2.4.0
       typescript: ^4.7.4
       vue: ^3.2.37
+      vue-demi: ^0.13.11
       vue2: npm:vue@^2.7.0-0
     dependencies:
       tslib: 2.4.0
@@ -82,6 +83,7 @@ importers:
       rollup-plugin-dts: 4.2.2_55kiftncucr43pz4hskma6yi2q
       typescript: 4.7.4
       vue: 3.2.37
+      vue-demi: 0.13.11_vue@3.2.37
       vue2: /vue/2.7.8
 
   packages/switch:
@@ -5622,6 +5624,21 @@ packages:
   /vscode-textmate/5.2.0:
     resolution: {integrity: sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==}
     dev: false
+
+  /vue-demi/0.13.11_vue@3.2.37:
+    resolution: {integrity: sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+    dependencies:
+      vue: 3.2.37
+    dev: true
 
   /vue-demi/0.13.5_vue@3.2.37:
     resolution: {integrity: sha512-tO3K2bML3AwiHmVHeKCq6HLef2st4zBXIV5aEkoJl6HZ+gJWxWv2O8wLH8qrA3SX3lDoTDHNghLX1xZg83MXvw==}


### PR DESCRIPTION
In order to use this project to make a Vue 3 library compatible with Vue `2.6.x`, `2.7`, and `3.x`, I had to fork it to use `vue-demi`. I know the docs say this library does not support versions under `2.7`, but this change allows me to bundle my library with `@vue-bridge/runtime` and `vue-demi` so that it runs in a `2.6.x` environment (for Nuxt 2).